### PR TITLE
User dynamic report naming for report export file names

### DIFF
--- a/src/app/reports/controllers/ReportsController.php
+++ b/src/app/reports/controllers/ReportsController.php
@@ -373,7 +373,7 @@ class ReportsController extends Controller
             if ($dataSource) {
                 $date = date('Ymd-his');
 
-                $filename = $report->name.'-'.$date;
+                $filename = ((string)$report).'-'.$date;
                 $labels = $dataSource->getDefaultLabels($report, $settings);
                 $values = $dataSource->getResults($report, $settings);
 


### PR DESCRIPTION
Leverage the __toString() function  of `Report` to use the dynamic report name when it's available.